### PR TITLE
♻️Refactor: playでもresultでも参照するため、スコア算出をトップに繰り上げ

### DIFF
--- a/my-app/src/app/ScoreProvider.tsx
+++ b/my-app/src/app/ScoreProvider.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+import { getAnswer } from '@/lib/play/get-question'
+
+type ScoreContextType = {
+  score: number
+  calculateScore: (answer: number, questionId: string) => void
+  resetScore: () => void
+}
+
+// 累積得点を管理するためのオブジェクト宣言
+const ScoreContext = createContext<ScoreContextType | null>(null)
+
+export function ScoreProvider({ children }: { children: React.ReactNode }) {
+  const [score, setScore] = useState<number>(0)
+  const calculateScore = (answer: number, questionId: string) => {
+    // ユーザー入力は「10.」のように小数点を混じらせた回答ができてしまうため小数点以下を排除
+    const user_ans = Math.trunc(answer)
+    const correct_ans = Number(getAnswer(questionId) || "0")
+    // 解答との乖離を絶対値で算出（最終スコア値が大きいほど、評価が低くなる）
+    setScore((v) => v + Math.abs(correct_ans - user_ans))
+  }
+  const resetScore = () => setScore(0)
+
+  return (
+    <ScoreContext.Provider value={{ score, calculateScore, resetScore }}>
+      {children}
+    </ScoreContext.Provider>
+  )
+}
+
+// ScoreContextを利用するためのカスタムフック
+export const useScore = () => {
+  const sctx = useContext(ScoreContext)
+  if (!sctx) throw new Error('useScoreはScoreProvider配下で使う必要があります')
+  return sctx
+}

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Kiwi_Maru } from "next/font/google";
 import "./globals.css";
+import { ScoreProvider } from "./ScoreProvider"
 
 const kiwiMaru = Kiwi_Maru({
   weight: "400",
@@ -21,7 +22,9 @@ export default function RootLayout({
     <html lang="ja">
       <body className={`${kiwiMaru.className} antialiased w-full min-h-screen flex flex-col items-center justify-between bg-white text-black`}>
         <main className="max-w-3xl md:max-w-5xl mx-auto grow">
-          {children}
+          <ScoreProvider>
+            {children}
+          </ScoreProvider>
         </main>
       </body>
     </html>

--- a/my-app/src/app/play/providers/PlayFormProvider.tsx
+++ b/my-app/src/app/play/providers/PlayFormProvider.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useRouter, useParams } from 'next/navigation'
-import { usePlay, useCalculateScore } from './PlayProvider'
-import { getAnswer } from '@/lib/play/get-question'
+import { usePlay } from './PlayProvider'
+import { useScore } from '@/app/ScoreProvider'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { answerFormSchema, AnswerFormInput, AnswerFormOutput } from '../schemas/play-form'
@@ -22,21 +22,20 @@ export function PlayFormProvider({ children }: { children: React.ReactNode }) {
   })
 
   // submit時に使用する状態
-  const reset = methods.reset
-  const { score, calculateScore } = useCalculateScore()
   const { questionId } = useParams<{ questionId: string }>()
   const { currentIndex, totalQuestions, next } = usePlay()
   const isLast = currentIndex === totalQuestions
-
+  const { score, calculateScore } = useScore()
   const router = useRouter()
+
   const onSubmit = (data: AnswerFormOutput) => {
     // バリデーションを通過していることが確実であるため、answerの型からundefinedを無視する
     const answer = data.answer!
     console.log('answer:', data.answer)
     console.log('questionId:', questionId)
-    next()  // 回答問題数をインクリメント
-    reset() // フォーム状態をリセット
-    calculateScore(answer, questionId)
+    next()          // 回答問題数をインクリメント
+    methods.reset() // フォーム状態をリセット
+    calculateScore(answer, questionId) // ユーザー回答と解答の乖離幅を算出
     console.log('更新前score:', score)
     isLast ? router.replace('/result') : router.replace('/play')
   }

--- a/my-app/src/app/play/providers/PlayProvider.tsx
+++ b/my-app/src/app/play/providers/PlayProvider.tsx
@@ -24,21 +24,6 @@ export function PlayProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
-// スコア算出用のカスタムフック（FormPloviderのonSubmitアクションで実行）
-export function useCalculateScore() {
-  const [score, setScore] = useState<number>(0)
-
-  const calculateScore = (answer: number, questionId: string) => {
-    // ユーザー入力は「10.」のように小数点を混じらせた回答ができてしまうため小数点以下を排除
-    const user_ans = Math.trunc(answer)
-    const correct_ans = Number(getAnswer(questionId) || "0")
-    // 解答との乖離を絶対値で算出（最終スコア値が大きいほど、評価が低くなる）
-    setScore((v) => v + Math.abs(correct_ans - user_ans))
-  }
-
-  return { score, calculateScore }
-}
-
 // PlayContextを利用するためのカスタムフック
 export const usePlay = () => {
   const ctx = useContext(PlayContext)


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
スコアに関する状態を管理するProviderをトップレベルに定義した。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
/play配下のフォームでスコアを更新し、/resultでスコアにより表示を分けるため、スコアの状態はまたいで参照できるようにする必要がある。
共通祖先はトップレベルになるため、スコアに関するProviderをトップレベルで定義するようにした。

## 結果
<!-- 対応した結果どうなったのかを記述 -->
/playでも/resultでもスコアを参照できるようになった。
