### PR TITLE
✨Add: PixabayAPIで画像をid取得するように変更

### DIFF
--- a/my-app/next.config.ts
+++ b/my-app/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'pixabay.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/my-app/public/data/questions.json
+++ b/my-app/public/data/questions.json
@@ -2,6 +2,7 @@
   {
     "id": "1",
     "question": {
+      "pixabay_id": "2679000",
       "target": "鉛筆",
       "scale": "長さ",
       "unit": "cm",

--- a/my-app/src/app/play/[questionId]/page.tsx
+++ b/my-app/src/app/play/[questionId]/page.tsx
@@ -5,23 +5,29 @@ import { CurrentQuestionNumber } from "./_components/current-question-number"
 import { AnswerField } from "./_components/answer-field"
 import { Suspense } from "react"
 import { ImageSkeleton } from "./_components/image-skeleton"
+import { getPixabayImage } from "@/lib/play/get-pixabay-image"
 
 export default async function QuestionPage({ params }: { params: Promise<{ questionId: string }> }) {
   const { questionId } = await params
   const question = await getQuestion(questionId)
-
-  // フォールバック処理
   if (!question) {
     console.log(`問題No.${questionId}の取得に失敗しました`)
     notFound()
   }
+
+  const hit = await getPixabayImage(question.pixabay_id)
+  if (!hit) return notFound()
 
   return (
     <div className="flex flex-col">
       <CurrentQuestionNumber />
       <div className="relative rounded h-[300px] w-auto bg-white">
         <Suspense fallback={<ImageSkeleton />}>
-          <Image src={`/questions_img/${questionId}.png`} alt="question_image" fill={true} />
+          <Image
+            src={hit.largeImageURL}
+            alt={hit.tags}
+            fill={true}
+          />
         </Suspense>
       </div>
       { question?.supplement && <div className="text-gray-400">{`※ ${question.supplement}`}</div> }

--- a/my-app/src/lib/play/get-pixabay-image.ts
+++ b/my-app/src/lib/play/get-pixabay-image.ts
@@ -1,0 +1,36 @@
+type PixabayHit = {
+  id: number
+  pageURL: string
+  tags: string
+  previewURL: string
+  webformatURL: string
+  largeImageURL: string
+}
+
+type PixabayResponse = {
+  total: number
+  totalHits: number
+  hits: PixabayHit[]
+}
+
+export async function getPixabayImage(pixabayId: string) {
+  const key = process.env.PIXABAY_API_KEY
+  if (!key) {
+    console.log('Pixabay API Keyが設定されていません')
+    throw new Error('Pixabay API Keyが設定されていません')
+  }
+
+  const url = new URL(`https://pixabay.com/api/?key=${key}&id=${pixabayId}`)
+
+  // Pixabay側のレート制限に合わせてキャッシュ
+  const res = await fetch(url, {
+    next: { revalidate: 60 * 60 * 24},
+  })
+
+  if (!res.ok) {
+    throw new Error(await res.text()) // APIエラー内容をそのまま投げる
+  }
+
+  const data = (await res.json()) as PixabayResponse
+  return data.hits[0] ?? null
+}

--- a/my-app/src/lib/play/get-question.ts
+++ b/my-app/src/lib/play/get-question.ts
@@ -1,6 +1,7 @@
 import questions from "@/../public/data/questions.json"
 
 type Question = {
+  pixabay_id: string
   target: string
   scale: string
   unit: string


### PR DESCRIPTION
## 概要
<!-- 対応した内容の概要を簡単に記述 -->
画像取得処理をPixabayAPIを活用したfetch処理に変更。

## 対応詳細
<!-- 対応した内容の詳細を記述 -->
テスト導入していたpublicの画像取得からAPI経由の画像取得に変更した。
ローカル環境では反映できることを確認済み。

## 結果
<!-- 対応した結果どうなったのかを記述 -->
画像が取得でき、スケルトンが一瞬表示されるようになった。